### PR TITLE
HOTFIX - change how we identify media-service in cn-media-upload directive

### DIFF
--- a/src/cn-media-upload.directive.js
+++ b/src/cn-media-upload.directive.js
@@ -110,7 +110,7 @@
       var size = file.size
       var blob = file.slice(start, start + step)
       var formData = new FormData();
-      if (vm.cnUploadPath.includes('/media/upload')) {
+      if (vm.cnUploadPath.includes('api/v2/media/upload')) {
         formData.append("content_hash", fileHash)
         formData.append("file", blob);
       } else {


### PR DESCRIPTION
`/media/upload` was colliding with routes like `/twitter/media/upload`.
By comparing the URL to `api/v2/media/upload` we shouldn't have this issue anymore.