### PR TITLE
API-3146 Use FB platform links from backend endpoints

### DIFF
--- a/src/cn-link-to-fb.directive.js
+++ b/src/cn-link-to-fb.directive.js
@@ -5,8 +5,6 @@
       .module('cn.ui')
       .directive('linkToFacebook', function() {
 
-        var base = 'https://www.facebook.com/ads/manage/summary/';
-
         return {
           restrict: 'E',
           replace: true,
@@ -26,18 +24,8 @@
             if($scope.fbObject.twitterLink) {
               $scope.link = $scope.fbObject.twitterLink;
             }
-            else if(_.has($scope.fbObject, 'fbCampaignGroupId')) {
-              if($scope.fbObject.fbCampaignGroupId) {
-                $scope.link = base + 'campaign/?campaign_id=' + $scope.fbObject.fbCampaignGroupId;
-              }
-            } else if(_.has($scope.fbObject, 'fbCampaignId')) {
-              if($scope.fbObject.fbCampaignId) {
-                $scope.link = base + 'adset/?ad_set_id=' + $scope.fbObject.fbCampaignId;
-              }
-            } else if(_.has($scope.fbObject, 'fbAdgroupId')) {
-              if($scope.fbObject.adSet.fbCampaignId && $scope.fbObject.fbAdgroupId) {
-                $scope.link = base + 'adset/?ad_set_id=' + $scope.fbObject.adSet.fbCampaignId + '&show_adgroup_id=' + $scope.fbObject.fbAdgroupId;
-              }
+            else if(_.has($scope.fbObject, 'platforms') && $scope.fbObject.platforms.origin) {
+              $scope.link = $scope.fbObject.platforms.origin;
             }
           }
         };


### PR DESCRIPTION
https://citizennet.atlassian.net/browse/API-3146

In conjunction with https://github.com/citizennet/backend/pull/4481, this will use the platform links from the backend endpoints instead of constructing them here. The links here are outdated and the associated PR is now generating the correct links.